### PR TITLE
fixed deprecated method

### DIFF
--- a/catalog_manager/app/it/gov/daf/catalogmanager/listeners/DirManager.scala
+++ b/catalog_manager/app/it/gov/daf/catalogmanager/listeners/DirManager.scala
@@ -1,28 +1,31 @@
+
 package it.gov.daf.catalogmanager.listeners
 
 /**
-  * Created by ale on 13/06/17.
-  */
+ * Created by ale on 13/06/17.
+ */
 
 import java.net.URLEncoder
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{FileIO, Source}
+import akka.stream.scaladsl.{ FileIO, Source }
 import net.caoticode.dirwatcher.FSListener
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSClient
 import play.api.mvc.MultipartFormData.FilePart
-
+import play.Logger
 import scala.concurrent.Future
 
-
-
 class DirManager() extends FSListener {
+
   import java.nio.file.Path
   import scala.concurrent.ExecutionContext.Implicits.global
 
+  val logger = Logger.underlying()
+
   override def onCreate(ref: Path): Unit = {
+
     implicit val system = ActorSystem()
     implicit val materializer = ActorMaterializer()
     val wsClient = AhcWSClient()
@@ -30,8 +33,8 @@ class DirManager() extends FSListener {
     val name = ref.getParent.getFileName.toString
     println(name)
     val uri: Option[String] = IngestionUtils.datasetsNameUri.get(name)
-    val logicalUri = URLEncoder.encode(uri.get)
-    println(logicalUri)
+    val logicalUri = URLEncoder.encode(uri.get, "UTF-8")
+    logger.debug("logicalUri: " + logicalUri)
 
     call(wsClient)
       .andThen { case _ => wsClient.close() }
@@ -41,15 +44,15 @@ class DirManager() extends FSListener {
       wsClient.url("http://localhost:9001/ingestion-manager/v1/add-datasets/" + logicalUri)
         //.withHeaders("content-type" -> "multipart/form-data")
         .post(
-        Source(FilePart("upfile", name, None, FileIO.fromPath(ref)) :: List())).map { response =>
-        val statusText: String = response.statusText
-        println(s"Got a response $statusText")
-      }
+          Source(FilePart("upfile", name, None, FileIO.fromPath(ref)) :: List())).map { response =>
+            val statusText: String = response.statusText
+            logger.debug(s"Got a response $statusText")
+          }
     }
-    println(s"created $ref")
+    logger.debug(s"created $ref")
   }
-
 
   override def onDelete(ref: Path): Unit = println(s"deleted $ref")
   override def onModify(ref: Path): Unit = println(s"modified $ref")
 }
+


### PR DESCRIPTION
removed warning for usage of deprecated method `URLEncoder.encode(...)`:

```bash
[warn] ...daf/catalog_manager/app/it/gov/daf/catalogmanager/listeners/DirManager.scala:33: method encode in object URLEncoder is deprecated: see corresponding Javadoc for more information.
[warn]     val logicalUri = URLEncoder.encode(uri.get)
[warn]                                 ^
[warn] one warning found
```