### PR TITLE
Link to the actual documentation in English

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the project homepage.
 
-* [Documentation for developers](https://developers.italia.it/it/daf/#documentazione)
+* [Documentation for developers](https://daf-docs.readthedocs.io/en/latest/)
 * [User Manual](docs-usr)
 
 ## Infrastructure setup


### PR DESCRIPTION
Old link went to the Developers portal in Italian, which did not have an English version in the language picker.